### PR TITLE
Allow the access token to be configured by appsettings file

### DIFF
--- a/Configuration/MasterserverConfiguration.cs
+++ b/Configuration/MasterserverConfiguration.cs
@@ -4,8 +4,8 @@ namespace BeatTogether.Api.Configuration
     public class MasterserverConfiguration
     {
         public string Endpoint { get; set; } = "BeatTogether.SomeIPAddress";
-        public string FullAccess { get; }  = "FULLACCESS"; //TODO Change this when put on main
-        public string CreateAndDestryPermanentServers { get; } = "MIDACCESS"; //TODO change this when put on main
+        public string FullAccess { get; set; }  = "FULLACCESS"; //TODO Change this when put on main
+        public string CreateAndDestryPermanentServers { get; set; } = "MIDACCESS"; //TODO change this when put on main
         //TODO make a better system for AccessTokens, eg loading a file into a data dictionary of access token to AllowedRequests, also save what access token made what server, so that only they can un-make the server
         //TODO cache values recieved from the master and dedi servers and only fetch from master or dedi if the last request was over 2 or 1 seconds ago to increase response timings if there are potentialy alot of users making many requests at once and reduce server lag.
     }

--- a/Program.cs
+++ b/Program.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using BeatTogether.DedicatedServer.Interface;
 using Autobus;
+using BeatTogether.Api.Configuration;
 using BeatTogether.MasterServer.Interface.ApiInterface;
 
 namespace BeatTogether.Status.Api
@@ -30,6 +31,7 @@ namespace BeatTogether.Status.Api
                                 .AddOptions()
                                 .Configure<StatusConfiguration>(hostBuilderContext.Configuration.GetSection("Status"))
                                 .Configure<QuickplayConfiguration>(hostBuilderContext.Configuration.GetSection("Quickplay"))
+                                .Configure<MasterserverConfiguration>(hostBuilderContext.Configuration.GetSection("Masterserver"))
                                 .AddControllers()
                                 
                         )


### PR DESCRIPTION
Add this section of json into your `appsettings.Production.json`
```
"Masterserver": {
    "Endpoint": "[Your Master Server IP]:[Port]",
    "FullAccess": "ChangeThis",
    "CreateAndDestryPermanentServers": "ChangeThis"
  }
```